### PR TITLE
Removed special handling to remove ":port"

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -114,7 +114,7 @@ Worker.prototype.handleRequest = function(req, res) {
   if (appkeys.length === 1) {
     app = this.mixdown.apps[appkeys[0]];
   } else {
-    host = req.headers.host.replace(/:\d+/, '');
+    host = req.headers.host; //it is perfectly fine to include port # here (if it's in the req.headers.host and will break on port specified vhosts.
     app = this.vhosts[host];
   }
 


### PR DESCRIPTION
- removed special handling to replace ":port" in req.headers.host as this.vhosts's keys will need to include port to be valid (so stripping port breaks any port specified vhost)
- Works fine without port specification as well, they just have to match.
